### PR TITLE
fix: Flutter min SDK version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,7 +44,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.mpv_remote"
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 18
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
https://pub.dev/packages/flutter_secure_storage#configure-android-version

```
uses-sdk:minSdkVersion 16 cannot be smaller than version 18 declared in library [:flutter_secure_storage] ~\src\github.com\darkwater\mpv_remote\build\flutter_secure_storage\intermediates\library_manifest\release\AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 18,
                or use tools:overrideLibrary="com.it_nomads.fluttersecurestorage" to force usage (may lead to runtime failures)

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:processReleaseMainManifest'.
> Manifest merger failed : uses-sdk:minSdkVersion 16 cannot be smaller than version 18 declared in library [:flutter_secure_storage] ~\src\github.com\darkwater\mpv_remote\build\flutter_secure_storage\intermediates\library_manifest\release\AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 18,
                or use tools:overrideLibrary="com.it_nomads.fluttersecurestorage" to force usage (may lead to runtime failures)

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 919ms
Running Gradle task 'assembleRelease'...                         1,514ms

┌─ Flutter Fix ─────────────────────────────────────────────────────────────────────────────────┐
│ The plugin flutter_secure_storage requires a higher Android SDK version.                      │
│ Fix this issue by adding the following to the file                                            │
│ ~\src\github.com\darkwater\mpv_remote\android\app\build.gradle:                               │
│ android {                                                                                     │
│   defaultConfig {                                                                             │
│     minSdkVersion 18                                                                          │
│   }                                                                                           │
│ }                                                                                             │
│                                                                                               │
│ Note that your app won't be available to users running Android SDKs below 18.                 │
│ Alternatively, try to find a version of this plugin that supports these lower versions of the │
│ Android SDK.                                                                                  │
└───────────────────────────────────────────────────────────────────────────────────────────────┘
Gradle task assembleRelease failed with exit code 1
```